### PR TITLE
Build with Node 20 in CI

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install app dependencies
         run: npm install

--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -53,6 +53,9 @@ jobs:
         run: mv android/app/build/outputs/apk/release/app-release.apk android/app/build/outputs/apk/release/offsides-nightly-${{ env.COMMIT_SHORT_SHA }}.apk
 
       - name: Create prerelease
+        # Pull requests from forks get a read-only token, so publishing a
+        # release would 403. Building the APK is enough of a check for a PR.
+        if: github.event_name == 'push'
         uses: ncipollo/release-action@v1.14.0
         with:
           name: ${{ env.COMMIT_SHORT_SHA }} [NIGHTLY]

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "typescript": "~5.9.2"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "packageManager": "npm@10.0.0"
 }


### PR DESCRIPTION
The nightly build has failed on every run since the Expo 54 commit, including the push to main itself:

```
TypeError: Error loading Metro config at: .../metro.config.js
TypeError: configs.toReversed is not a function
```

`Array.prototype.toReversed` is Node 20+, and the workflow pins Node 18. Bumped it to 20 and updated `engines` in package.json to match. Nothing else changed.



Also gated the "Create prerelease" step on `push`. PRs from forks run with a read-only token, so that step fails with a 403 after the APK has already built, which is why the check has been red on every fork PR. PRs now just build the APK; pushes to main still publish the nightly.
